### PR TITLE
Add support for Xcode 11 and multiple sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,20 @@ So basically it’s supposed to run pretty much everywhere, bringing you the imm
 `TODO`
 ### Manually
 `TODO`
+#### Xcode
+Xcode doesn't provide a seamless way to add new themes, so you'll need to copy these [contents](themes/Xcode) into
+```
+~/Library/Developer/Xcode/UserData/FontAndColorThemes/
+```
+An easy way to get there is to open a Finder window and use the command `⌘ + ⇧ + G` and paste the path there.
+
 ## Contributing
 `TODO`
 
 ## Screenshots
 `TODO`
 
-## Acknowledgements 
+## Acknowledgements
 `TODO mention repo inspiration in Cocoapods Moya`
 
 ## License

--- a/themes/Xcode/Glip Glops Presentation Large.xccolortheme
+++ b/themes/Xcode/Glip Glops Presentation Large.xccolortheme
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>SFMono-Regular - 11.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.196078 0.811765 0.447059 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>SFMono-Regular - 11.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.118 0.125 0.157 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.397 0.397 0.302 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.12 0.31 0.34 1</string>
+	<key>DVTFontAndColorVersion</key>
+	<integer>1</integer>
+	<key>DVTLineSpacing</key>
+	<real>1.1000000238418579</real>
+	<key>DVTMarkupTextBackgroundColor</key>
+	<string>0.18856 0.195 0.22444 1</string>
+	<key>DVTMarkupTextBorderColor</key>
+	<string>0.253475 0.2594 0.286485 1</string>
+	<key>DVTMarkupTextCodeFont</key>
+	<string>SFMono-Regular - 10.0</string>
+	<key>DVTMarkupTextEmphasisColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextEmphasisFont</key>
+	<string>.AppleSystemUIFontItalic - 10.0</string>
+	<key>DVTMarkupTextInlineCodeColor</key>
+	<string>1 1 1 0.7</string>
+	<key>DVTMarkupTextLinkColor</key>
+	<string>0.33 0.247124 0.894195 1</string>
+	<key>DVTMarkupTextLinkFont</key>
+	<string>.AppleSystemUIFont - 10.0</string>
+	<key>DVTMarkupTextNormalColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextNormalFont</key>
+	<string>.AppleSystemUIFont - 10.0</string>
+	<key>DVTMarkupTextOtherHeadingColor</key>
+	<string>1 1 1 0.5</string>
+	<key>DVTMarkupTextOtherHeadingFont</key>
+	<string>.AppleSystemUIFont - 14.0</string>
+	<key>DVTMarkupTextPrimaryHeadingColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextPrimaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 24.0</string>
+	<key>DVTMarkupTextSecondaryHeadingColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextSecondaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 18.0</string>
+	<key>DVTMarkupTextStrongColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextStrongFont</key>
+	<string>.AppleSystemUIFontBold - 10.0</string>
+	<key>DVTScrollbarMarkerAnalyzerColor</key>
+	<string>0.403922 0.372549 1 1</string>
+	<key>DVTScrollbarMarkerBreakpointColor</key>
+	<string>0.290196 0.290196 0.968627 1</string>
+	<key>DVTScrollbarMarkerDiffColor</key>
+	<string>0.556863 0.556863 0.556863 1</string>
+	<key>DVTScrollbarMarkerDiffConflictColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerErrorColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerRuntimeIssueColor</key>
+	<string>0.643137 0.509804 1 1</string>
+	<key>DVTScrollbarMarkerWarningColor</key>
+	<string>0.937255 0.717647 0.34902 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.121569 0.12549 0.160784 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.156863 0.160784 0.219608 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.298039 0.298039 0.298039 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.207843 0.25098 0.305882 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.335 0.456 0.488 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.469 0.426 0.77 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.643137 0.643137 0.643137 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.513725 0.752941 0.341176 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.513725 0.752941 0.341176 1</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.999999 0.999974 0.999991 1</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.999999 0.999974 0.999991 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0 0.627451 0.745098 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0 0.627451 0.745098 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.776471 0.486275 0.282353 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.778 0.488 0.284 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.847059 0.0666667 0.588235 1</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.572549 0.631373 0.694118 1</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>0.847059 0.0666667 0.588235 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.0784314 0.611765 0.572549 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>1 1 1 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.721639 0.407778 0.220632 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.858824 0.172549 0.219608 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.254902 0.333333 0.819608 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.character</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>FiraCode-Bold - 28.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>SFMono-RegularItalic - 28.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>FiraCode-Bold - 28.0</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.number</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>FiraCode-Retina - 28.0</string>
+		<key>xcode.syntax.string</key>
+		<string>SFMono-RegularItalic - 28.0</string>
+		<key>xcode.syntax.url</key>
+		<string>FiraCode-Retina - 28.0</string>
+	</dict>
+</dict>
+</plist>

--- a/themes/Xcode/Glip Glops Presentation.xccolortheme
+++ b/themes/Xcode/Glip Glops Presentation.xccolortheme
@@ -30,6 +30,8 @@
 	<string>0.397 0.397 0.302 1</string>
 	<key>DVTDebuggerInstructionPointerColor</key>
 	<string>0.12 0.31 0.34 1</string>
+	<key>DVTFontAndColorVersion</key>
+	<integer>1</integer>
 	<key>DVTLineSpacing</key>
 	<real>1.1000000238418579</real>
 	<key>DVTMarkupTextBackgroundColor</key>
@@ -68,6 +70,20 @@
 	<string>1 1 1 1</string>
 	<key>DVTMarkupTextStrongFont</key>
 	<string>.AppleSystemUIFontBold - 10.0</string>
+	<key>DVTScrollbarMarkerAnalyzerColor</key>
+	<string>0.403922 0.372549 1 1</string>
+	<key>DVTScrollbarMarkerBreakpointColor</key>
+	<string>0.290196 0.290196 0.968627 1</string>
+	<key>DVTScrollbarMarkerDiffColor</key>
+	<string>0.556863 0.556863 0.556863 1</string>
+	<key>DVTScrollbarMarkerDiffConflictColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerErrorColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerRuntimeIssueColor</key>
+	<string>0.643137 0.509804 1 1</string>
+	<key>DVTScrollbarMarkerWarningColor</key>
+	<string>0.937255 0.717647 0.34902 1</string>
 	<key>DVTSourceTextBackground</key>
 	<string>0.121569 0.12549 0.160784 1</string>
 	<key>DVTSourceTextBlockDimBackgroundColor</key>
@@ -92,6 +108,10 @@
 		<string>0.513725 0.752941 0.341176 1</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
 		<string>0.513725 0.752941 0.341176 1</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.999999 0.999974 0.999991 1</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.999999 0.999974 0.999991 1</string>
 		<key>xcode.syntax.identifier.class</key>
 		<string>0.196078 0.811765 0.447059 1</string>
 		<key>xcode.syntax.identifier.class.system</key>
@@ -118,6 +138,10 @@
 		<string>0 0.626 0.746 1</string>
 		<key>xcode.syntax.keyword</key>
 		<string>0.847059 0.0666667 0.588235 1</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.572549 0.631373 0.694118 1</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>0.847059 0.0666667 0.588235 1</string>
 		<key>xcode.syntax.number</key>
 		<string>0.0784314 0.611765 0.572549 1</string>
 		<key>xcode.syntax.plain</key>
@@ -132,51 +156,59 @@
 	<key>DVTSourceTextSyntaxFonts</key>
 	<dict>
 		<key>xcode.syntax.attribute</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.character</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.comment</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.comment.doc</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.comment.doc.keyword</key>
-		<string>FiraCode-Bold - 11.0</string>
+		<string>FiraCode-Bold - 18.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>FiraCode-Retina - 18.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.class</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.class.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.constant</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.constant.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.function</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.function.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.macro</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.macro.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.type</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.type.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.variable</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.identifier.variable.system</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.keyword</key>
-		<string>SFMono-RegularItalic - 11.0</string>
+		<string>SFMono-RegularItalic - 18.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>FiraCode-Bold - 18.0</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.number</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.plain</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.preprocessor</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 		<key>xcode.syntax.string</key>
-		<string>SFMono-RegularItalic - 11.0</string>
+		<string>SFMono-RegularItalic - 18.0</string>
 		<key>xcode.syntax.url</key>
-		<string>FiraCode-Retina - 11.0</string>
+		<string>FiraCode-Retina - 18.0</string>
 	</dict>
 </dict>
 </plist>

--- a/themes/Xcode/Glip Glops.xccolortheme
+++ b/themes/Xcode/Glip Glops.xccolortheme
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>DVTConsoleDebuggerInputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleDebuggerInputTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleDebuggerOutputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleDebuggerOutputTextFont</key>
+	<string>SFMono-Regular - 11.0</string>
+	<key>DVTConsoleDebuggerPromptTextColor</key>
+	<string>0.196078 0.811765 0.447059 1</string>
+	<key>DVTConsoleDebuggerPromptTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleExectuableInputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleExectuableInputTextFont</key>
+	<string>SFMono-Regular - 11.0</string>
+	<key>DVTConsoleExectuableOutputTextColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleExectuableOutputTextFont</key>
+	<string>SFMono-Bold - 11.0</string>
+	<key>DVTConsoleTextBackgroundColor</key>
+	<string>0.118 0.125 0.157 1</string>
+	<key>DVTConsoleTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTConsoleTextSelectionColor</key>
+	<string>0.397 0.397 0.302 1</string>
+	<key>DVTDebuggerInstructionPointerColor</key>
+	<string>0.12 0.31 0.34 1</string>
+	<key>DVTFontAndColorVersion</key>
+	<integer>1</integer>
+	<key>DVTLineSpacing</key>
+	<real>1.1000000238418579</real>
+	<key>DVTMarkupTextBackgroundColor</key>
+	<string>0.18856 0.195 0.22444 1</string>
+	<key>DVTMarkupTextBorderColor</key>
+	<string>0.253475 0.2594 0.286485 1</string>
+	<key>DVTMarkupTextCodeFont</key>
+	<string>SFMono-Regular - 10.0</string>
+	<key>DVTMarkupTextEmphasisColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextEmphasisFont</key>
+	<string>.AppleSystemUIFontItalic - 10.0</string>
+	<key>DVTMarkupTextInlineCodeColor</key>
+	<string>1 1 1 0.7</string>
+	<key>DVTMarkupTextLinkColor</key>
+	<string>0.33 0.247124 0.894195 1</string>
+	<key>DVTMarkupTextLinkFont</key>
+	<string>.AppleSystemUIFont - 10.0</string>
+	<key>DVTMarkupTextNormalColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextNormalFont</key>
+	<string>.AppleSystemUIFont - 10.0</string>
+	<key>DVTMarkupTextOtherHeadingColor</key>
+	<string>1 1 1 0.5</string>
+	<key>DVTMarkupTextOtherHeadingFont</key>
+	<string>.AppleSystemUIFont - 14.0</string>
+	<key>DVTMarkupTextPrimaryHeadingColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextPrimaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 24.0</string>
+	<key>DVTMarkupTextSecondaryHeadingColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextSecondaryHeadingFont</key>
+	<string>.AppleSystemUIFont - 18.0</string>
+	<key>DVTMarkupTextStrongColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTMarkupTextStrongFont</key>
+	<string>.AppleSystemUIFontBold - 10.0</string>
+	<key>DVTScrollbarMarkerAnalyzerColor</key>
+	<string>0.403922 0.372549 1 1</string>
+	<key>DVTScrollbarMarkerBreakpointColor</key>
+	<string>0.290196 0.290196 0.968627 1</string>
+	<key>DVTScrollbarMarkerDiffColor</key>
+	<string>0.556863 0.556863 0.556863 1</string>
+	<key>DVTScrollbarMarkerDiffConflictColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerErrorColor</key>
+	<string>0.968627 0.290196 0.290196 1</string>
+	<key>DVTScrollbarMarkerRuntimeIssueColor</key>
+	<string>0.643137 0.509804 1 1</string>
+	<key>DVTScrollbarMarkerWarningColor</key>
+	<string>0.937255 0.717647 0.34902 1</string>
+	<key>DVTSourceTextBackground</key>
+	<string>0.121569 0.12549 0.160784 1</string>
+	<key>DVTSourceTextBlockDimBackgroundColor</key>
+	<string>0.5 0.5 0.5 1</string>
+	<key>DVTSourceTextCurrentLineHighlightColor</key>
+	<string>0.156863 0.160784 0.219608 1</string>
+	<key>DVTSourceTextInsertionPointColor</key>
+	<string>1 1 1 1</string>
+	<key>DVTSourceTextInvisiblesColor</key>
+	<string>0.298039 0.298039 0.298039 1</string>
+	<key>DVTSourceTextSelectionColor</key>
+	<string>0.207843 0.25098 0.305882 1</string>
+	<key>DVTSourceTextSyntaxColors</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>0.335 0.456 0.488 1</string>
+		<key>xcode.syntax.character</key>
+		<string>0.469 0.426 0.77 1</string>
+		<key>xcode.syntax.comment</key>
+		<string>0.643137 0.643137 0.643137 1</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>0.513725 0.752941 0.341176 1</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>0.513725 0.752941 0.341176 1</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>0.999999 0.999974 0.999991 1</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>0.999999 0.999974 0.999991 1</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>0 0.627451 0.745098 1</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>0 0.627451 0.745098 1</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>0.776471 0.486275 0.282353 1</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>0.778 0.488 0.284 1</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>0.196078 0.811765 0.447059 1</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>0 0.626 0.746 1</string>
+		<key>xcode.syntax.keyword</key>
+		<string>0.847059 0.0666667 0.588235 1</string>
+		<key>xcode.syntax.mark</key>
+		<string>0.572549 0.631373 0.694118 1</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>0.847059 0.0666667 0.588235 1</string>
+		<key>xcode.syntax.number</key>
+		<string>0.0784314 0.611765 0.572549 1</string>
+		<key>xcode.syntax.plain</key>
+		<string>1 1 1 1</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>0.721639 0.407778 0.220632 1</string>
+		<key>xcode.syntax.string</key>
+		<string>0.858824 0.172549 0.219608 1</string>
+		<key>xcode.syntax.url</key>
+		<string>0.254902 0.333333 0.819608 1</string>
+	</dict>
+	<key>DVTSourceTextSyntaxFonts</key>
+	<dict>
+		<key>xcode.syntax.attribute</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.character</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.comment</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.comment.doc</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.comment.doc.keyword</key>
+		<string>FiraCode-Bold - 11.0</string>
+		<key>xcode.syntax.declaration.other</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.declaration.type</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.class</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.class.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.constant</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.constant.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.function</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.function.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.macro</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.macro.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.type</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.type.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.variable</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.identifier.variable.system</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.keyword</key>
+		<string>SFMono-RegularItalic - 11.0</string>
+		<key>xcode.syntax.mark</key>
+		<string>FiraCode-Bold - 11.0</string>
+		<key>xcode.syntax.markup.code</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.number</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.plain</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.preprocessor</key>
+		<string>FiraCode-Retina - 11.0</string>
+		<key>xcode.syntax.string</key>
+		<string>SFMono-RegularItalic - 11.0</string>
+		<key>xcode.syntax.url</key>
+		<string>FiraCode-Retina - 11.0</string>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
Xcode 11 adds dedicated syntax coloring for _Type Declarations_ and _Other Declarations_. These were added to the theme since if not present, they'd take another colour from another theme.

## Changes
- Updated `Glip Glops` with newly available syntax
- Created `Glip Glops Presentation`
- Created `Glip Glops Presentation Large`
- Added instructions on how to manually add themes to Xcode 